### PR TITLE
Now you can get the note number that is being pressed

### DIFF
--- a/Assets/MidiJack/Midi.cs
+++ b/Assets/MidiJack/Midi.cs
@@ -62,13 +62,13 @@ namespace MidiJack
 
         public override string ToString()
         {
-            string fmt = "s({0:X2}) d({1:X2},{2:X2}) from {3:X8}";
+            const string fmt = "s({0:X2}) d({1:X2},{2:X2}) from {3:X8}";
             return string.Format(fmt, status, data1, data2, source);
         }
 
-		public int NoteNumber(){
-			string fmt = "{0:X2}";
-			return System.Int32.Parse( string.Format(fmt, data1), System.Globalization.NumberStyles.AllowHexSpecifier );
-		}
+	public int NoteNumber(){
+		const string fmt = "{0:X2}";
+		return System.Int32.Parse( string.Format(fmt, data1), System.Globalization.NumberStyles.AllowHexSpecifier );
+	}
     }
 }

--- a/Assets/MidiJack/Midi.cs
+++ b/Assets/MidiJack/Midi.cs
@@ -62,8 +62,13 @@ namespace MidiJack
 
         public override string ToString()
         {
-            const string fmt = "s({0:X2}) d({1:X2},{2:X2}) from {3:X8}";
+            string fmt = "s({0:X2}) d({1:X2},{2:X2}) from {3:X8}";
             return string.Format(fmt, status, data1, data2, source);
         }
+
+		public int NoteNumber(){
+			string fmt = "{0:X2}";
+			return System.Int32.Parse( string.Format(fmt, data1), System.Globalization.NumberStyles.AllowHexSpecifier );
+		}
     }
 }

--- a/Assets/MidiJack/MidiDriver.cs
+++ b/Assets/MidiJack/MidiDriver.cs
@@ -98,6 +98,13 @@ namespace MidiJack
             return defaultValue;
         }
 
+		public int GetNoteNumber()
+		{
+			var data = DequeueIncomingData();
+			var message = new MidiMessage(data);
+			return message.NoteNumber();
+		}
+
         #endregion
 
         #region Editor Support

--- a/Assets/MidiJack/MidiMaster.cs
+++ b/Assets/MidiJack/MidiMaster.cs
@@ -78,5 +78,10 @@ namespace MidiJack
         {
             return MidiDriver.Instance.GetKnob(MidiChannel.All, knobNumber, defaultValue);
         }
+
+		public static int GetNoteNumber()
+		{
+			return MidiDriver.Instance.GetNoteNumber();
+		}
     }
 }


### PR DESCRIPTION
I want to make some kind of custom configuration where i could call for example the note "38" as "snare" and pass "snare" to the getKeyDown method.

But not simply as that, i have to make this "snare" customizable, so i can go to options and set the "snare" variable to any key number i wanted to but not by hand, instead, the player should press the key then according to the key he pressed, it will be the new "snare". To do this, i didn't knew any way to get the actual number of the note that is being pressed so i worked on it.

After reading the scripts, i started to play with it and ended with an easy way to get the number of the keynote that is being pressed right now so i can set it to an it, and use it on the getKeyDown method later.

I don't know if i could use some other kind of workaround to do the same, i'm still pretty new to unity and coding in general, and i think there's a lack of tutorial for some parts for the plugin and i missed this thing where i could know what key i'm pressing in the same way i can give it to the getKeyDown method
