### PR TITLE
Fix MidiJackGetEndpointName() for 64-bit Windows

### DIFF
--- a/VisualStudio/MidiJackPlugin/stdafx.h
+++ b/VisualStudio/MidiJackPlugin/stdafx.h
@@ -9,6 +9,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <string>
+#include <map>
 #include <mutex>
 #include <queue>
 #include <list>


### PR DESCRIPTION
The old DeviceIdToHandle() truncated the top 32 bits, yielding an
invalid/unknown handle. The handles are now cached in a lookup map,
accessible by DeviceID.

Fixes #37

